### PR TITLE
fix: don't throw error with partial initialized app

### DIFF
--- a/app/src/__tests__/app.helper.spec.ts
+++ b/app/src/__tests__/app.helper.spec.ts
@@ -40,6 +40,22 @@ class TestModule1 {}
 )
 class TestModule2 {}
 
+@Module(
+  yalcBaseAppModuleMetadataFactory(BrokenModule, 'brokenModule', {
+    configFactory: () => ({}),
+    logger: true,
+    providers: [
+      {
+        provide: 'brokenService',
+        useFactory: () => {
+          throw new Error('Test');
+        },
+      },
+    ],
+  }),
+)
+class BrokenModule {}
+
 describe('test standalone app functions', () => {
   let mockedModule: DeepMocked<DynamicModule>;
   let mockedServiceFunction: jest.Mock<() => string>;
@@ -133,6 +149,25 @@ describe('test standalone app functions', () => {
     }
 
     await expect(error).not.toBe(null);
+  });
+
+  it('should not trigger an error when the first app cannot be initialized because of an error', async () => {
+    try {
+      await new AppBootstrap('brokenModule', BrokenModule).initApp();
+    } catch (e: any) {
+      // nothing
+    }
+
+    let error: any = null;
+    try {
+      await new AppBootstrap('test2', TestModule2, {}).initApp();
+    } catch (e: any) {
+      // eslint-disable-next-line no-console
+      console.log(e);
+      error = e;
+    }
+
+    await expect(error).toBe(null);
   });
 
   it('should not trigger an error if we bootstrap multiple servers with the skip option', async () => {

--- a/app/src/app-bootstrap-standalone.helper.ts
+++ b/app/src/app-bootstrap-standalone.helper.ts
@@ -49,6 +49,7 @@ export class StandaloneAppBootstrap<
         logger: getEnvLoggerLevels(),
       });
     } catch (err) {
+      this.closeCleanup();
       // eslint-disable-next-line no-console
       console.error(clc.red('Failed to create app'), clc.red(err));
       throw new Error('Process aborted');

--- a/app/src/app-bootstrap.helper.ts
+++ b/app/src/app-bootstrap.helper.ts
@@ -85,9 +85,14 @@ export class AppBootstrap<
     createOptions?: ICreateOptions;
     fastifyInstance?: FastifyInstance;
   }) {
-    await this.applyBootstrapGlobals(options?.createOptions);
+    try {
+      await this.applyBootstrapGlobals(options?.createOptions);
 
-    await this.getApp().init();
+      await this.getApp().init();
+    } catch (err) {
+      this.closeCleanup();
+      throw new Error('Process aborted');
+    }
 
     if (envIsTrue(process.env.APP_DRY_RUN) === true) {
       this.loggerService?.log('Dry run, exiting...');
@@ -117,6 +122,7 @@ export class AppBootstrap<
         },
       );
     } catch (err) {
+      this.closeCleanup();
       // eslint-disable-next-line no-console
       console.error(clc.red('Failed to create app'), clc.red(err));
       throw new Error('Process aborted');


### PR DESCRIPTION
This is for the multiple instances of the app in the same process.