### PR TITLE
chore: bump swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "@nestjs/jwt": "^10.0.1",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-fastify": "^9.2.1",
-        "@nestjs/swagger": "^6.1.4",
+        "@nestjs/swagger": "^6.3.0",
         "@nestjs/typeorm": "^9.0.1",
         "axios": "^1.4.0",
         "nestjs-cls": "^3.6.0"
@@ -3437,6 +3437,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz",
+      "integrity": "sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==",
+      "peer": true,
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "9.3.9",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-9.3.9.tgz",
@@ -3547,16 +3567,16 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-6.1.4.tgz",
-      "integrity": "sha512-kE8VjR+NaoKqxg8XqM/YYfALScPh4AcoR8Wywga8/OxHsTHY+MKxqvTpWp7IhCUWSA6xT8nQUpcC9Rt7C+r7Hw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-6.3.0.tgz",
+      "integrity": "sha512-Gnig189oa1tD+h0BYIfUwhp/wvvmTn6iO3csR2E4rQrDTgCxSxZDlNdfZo3AC+Rmf8u0KX4ZAX1RZN1qXTtC7A==",
       "peer": true,
       "dependencies": {
-        "@nestjs/mapped-types": "1.2.0",
+        "@nestjs/mapped-types": "1.2.2",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
         "path-to-regexp": "3.2.0",
-        "swagger-ui-dist": "4.15.5"
+        "swagger-ui-dist": "4.18.2"
       },
       "peerDependencies": {
         "@fastify/static": "^6.0.0",
@@ -3570,26 +3590,6 @@
         "@fastify/static": {
           "optional": true
         },
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.0.tgz",
-      "integrity": "sha512-NTFwPZkQWsArQH8QSyFWGZvJ08gR+R4TofglqZoihn/vU+ktHEJjMqsIsADwb7XD97DhiD+TVv5ac+jG33BHrg==",
-      "peer": true,
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
-        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
-        "reflect-metadata": "^0.1.12"
-      },
-      "peerDependenciesMeta": {
         "class-transformer": {
           "optional": true
         },
@@ -12942,9 +12942,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
-      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.18.2.tgz",
+      "integrity": "sha512-oVBoBl9Dg+VJw8uRWDxlyUyHoNEDC0c1ysT6+Boy6CTgr2rUcLcfPon4RvxgS2/taNW6O0+US+Z/dlAsWFjOAQ==",
       "peer": true
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@nestjs/jwt": "^10.0.1",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-fastify": "^9.2.1",
-    "@nestjs/swagger": "^6.1.4",
+    "@nestjs/swagger": "^6.3.0",
     "@nestjs/typeorm": "^9.0.1",
     "axios": "^1.4.0",
     "nestjs-cls": "^3.6.0"


### PR DESCRIPTION
Fixes:

GitHub Actions
/ Common libs build tests
Argument of type '{ jsonDocumentUrl: string; }' is not assignable to parameter of type 'SwaggerCustomOptions'.