### PR TITLE
feat: allow json parse to be skipped

### DIFF
--- a/api-strategy/src/__tests__/nest-local-call.strategy.spec.ts
+++ b/api-strategy/src/__tests__/nest-local-call.strategy.spec.ts
@@ -91,6 +91,34 @@ describe('NestLocalCallStrategy', () => {
     expect(result).toBeDefined();
   });
 
+  it('should skip parsing json if json parse throws an error', async () => {
+    adapterHost = createMock<HttpAdapterHost>({
+      httpAdapter: {
+        getInstance: () =>
+          createMock<FastifyAdapter>({
+            inject: (
+              _opts: string | InjectOptions,
+            ): PartialFuncReturn<Promise<any>> =>
+              ({
+                body: '{',
+                json: () => {
+                  throw new Error('test');
+                },
+              } as any),
+          }),
+      },
+    });
+
+    const instance = new NestLocalCallStrategy(adapterHost, clsService);
+    expect(instance).toBeDefined();
+
+    const result = await instance.call('http://localhost:3000', {
+      method: 'GET',
+    });
+
+    expect(result.data).toEqual('{');
+  });
+
   it('should skip parsing json if shouldSkipJsonParse is true', async () => {
     const instance = new NestLocalCallStrategy(
       adapterHost,

--- a/api-strategy/src/__tests__/nest-local-call.strategy.spec.ts
+++ b/api-strategy/src/__tests__/nest-local-call.strategy.spec.ts
@@ -29,7 +29,11 @@ describe('NestLocalCallStrategy', () => {
           createMock<FastifyAdapter>({
             inject: (
               _opts: string | InjectOptions,
-            ): PartialFuncReturn<Promise<any>> => ({ body: '{}' } as any),
+            ): PartialFuncReturn<Promise<any>> =>
+              ({
+                body: '{}',
+                json: () => ({}),
+              } as any),
           }),
       },
     });
@@ -85,5 +89,56 @@ describe('NestLocalCallStrategy', () => {
       },
     });
     expect(result).toBeDefined();
+  });
+
+  it('should skip parsing json if shouldSkipJsonParse is true', async () => {
+    const instance = new NestLocalCallStrategy(
+      adapterHost,
+      clsService,
+      // @ts-expect-error isnt needed for test
+      {},
+      '',
+      {
+        shouldSkipJsonParse: (body) => true,
+      },
+    );
+    expect(instance).toBeDefined();
+
+    const result = await instance.call('http://localhost:3000', {
+      method: 'GET',
+    });
+
+    expect(result.data).toEqual('{}');
+  });
+
+  it('should parse json if shouldSkipJsonParse is false', async () => {
+    const instance = new NestLocalCallStrategy(
+      adapterHost,
+      clsService,
+      // @ts-expect-error isnt needed for test
+      {},
+      '',
+      {
+        shouldSkipJsonParse: (body) => false,
+      },
+    );
+    expect(instance).toBeDefined();
+
+    const result = await instance.call('http://localhost:3000', {
+      method: 'GET',
+    });
+
+    expect(result.data).toMatchObject({});
+  });
+
+  it('should parse json if shouldSkipJsonParse is undefined', async () => {
+    const instance = new NestLocalCallStrategy(adapterHost, clsService);
+    expect(instance).toBeDefined();
+
+    const result = await instance.call('http://localhost:3000', {
+      method: 'GET',
+    });
+
+    expect(result.data).toMatchObject({});
   });
 });

--- a/api-strategy/src/strategies/http-abstract-call.strategy.ts
+++ b/api-strategy/src/strategies/http-abstract-call.strategy.ts
@@ -4,6 +4,7 @@ import { IApiCallStrategy } from '../context-call.interface.js';
 
 export interface IHttpCallStrategyOptions {
   headersWhitelist?: string[];
+  shouldSkipJsonParse?: (body: string) => boolean;
 }
 
 /**

--- a/api-strategy/src/strategies/nest-local-call.strategy.ts
+++ b/api-strategy/src/strategies/nest-local-call.strategy.ts
@@ -70,7 +70,14 @@ export class NestLocalCallStrategy extends HttpAbstractStrategy {
 
     let data;
     try {
-      data = result.json();
+      if (
+        this.options.shouldSkipJsonParse &&
+        this.options.shouldSkipJsonParse(result.body)
+      ) {
+        data = result.body;
+      } else {
+        data = result.json();
+      }
     } catch (_e) {
       //The content-type of the response is not application/json
       // if so, we use the body instead


### PR DESCRIPTION
- introduces option to pass function which determines which body should not be json parsed.

## Background
- necessary for fungs uses where some IDs are interpreted as hex numbers by JSON.parse and result in `Infinity`. This breaks eg the authorizer (the userAccountId is set as `Infinity` by the authorizer and the user may never get authorized)

### Specific example
![Uploading Screenshot 2025-01-16 at 17.51.42.png…]()
