### PR TITLE
feat: add public example mirror tooling

### DIFF
--- a/.github/workflows/example-mirrors.yml
+++ b/.github/workflows/example-mirrors.yml
@@ -1,0 +1,72 @@
+name: public example mirrors
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Sync without pushing mirror commits
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches:
+      - dev
+    paths:
+      - examples/skeleton/**
+      - examples/omnikernel/**
+      - examples/task/**
+      - scripts/export-public-examples.mjs
+      - scripts/sync-public-example-mirrors.mjs
+      - .github/workflows/example-mirrors.yml
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  sync:
+    name: Sync generated example mirrors
+    runs-on: ubuntu-latest
+    if: github.repository == 'NestDevLab/nestjs-yalc'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Configure Git author
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check mirror token
+        env:
+          EXAMPLE_MIRROR_TOKEN: ${{ secrets.EXAMPLE_MIRROR_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: |
+          if [ "$DRY_RUN" != "true" ] && [ -z "$EXAMPLE_MIRROR_TOKEN" ]; then
+            echo "EXAMPLE_MIRROR_TOKEN is required to push external mirror repositories."
+            exit 1
+          fi
+
+      - name: Sync mirrors
+        env:
+          EXAMPLE_MIRROR_TOKEN: ${{ secrets.EXAMPLE_MIRROR_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            npm run examples:mirror:dry-run
+          else
+            npm run examples:mirror
+          fi

--- a/.github/workflows/example-mirrors.yml
+++ b/.github/workflows/example-mirrors.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: example-mirrors-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   NODE_VERSION: 24
 

--- a/data-loader/src/dataloader.helper.ts
+++ b/data-loader/src/dataloader.helper.ts
@@ -6,6 +6,7 @@ import { IWhereCondition } from '@nestjs-yalc/crud-gen/api-graphql/crud-gen-gql.
 import { Operators } from '@nestjs-yalc/crud-gen/crud-gen.enum.js';
 import {
   FactoryProvider,
+  InjectionToken,
   NotAcceptableException,
   NotFoundException,
   Optional,
@@ -18,7 +19,7 @@ import {
 import { ClassType } from '@nestjs-yalc/types/globals.d.js';
 import { getProviderToken } from '@nestjs-yalc/crud-gen/crud-gen.helpers.js';
 import { EventCrudGen } from '@nestjs-yalc/crud-gen/event.enum.js';
-import * as eventemitter2 from 'eventemitter2';
+import EventEmitter2Class from 'eventemitter2';
 import { type EventEmitter2 } from 'eventemitter2';
 
 export type SearchKeyType<E, T = string> = [keyof E, T] | T | undefined;
@@ -295,7 +296,7 @@ export function DataLoaderFactory<Entity extends Record<string, any>>(
     },
     inject: [
       serviceToken ?? getServiceToken(entity),
-      eventemitter2.EventEmitter2,
+      EventEmitter2Class as unknown as InjectionToken,
     ],
     scope: Scope.REQUEST,
   };

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Nest-yalc stands for Nestjs - Yet Another Library Collection
 - [Backend blueprint: the opinionated way to use nestjs-yalc for new backends](./backend-blueprint.md)
 - [Framework hardening follow-ups after PR #121](./framework-hardening-followups.md)
 - [Public npm publication](./npm-publication.md)
+- [Public example mirrors](./public-example-mirrors.md)
 
 ## NPM package.json and Workspace
 

--- a/docs/npm-publication.md
+++ b/docs/npm-publication.md
@@ -242,13 +242,18 @@ The export command writes standalone example sources under `var/example-exports`
 - `var/example-exports/task`
 
 During export, framework dependencies such as `@nestjs-yalc/crud-gen` and
-`@nestjs-yalc/framework` are rewritten to the current public version range.
-Example-local packages stay as local `file:` dependencies inside the exported
-tree, for example `@nestjs-yalc/skeleton-module` or
+`@nestjs-yalc/framework` are rewritten to their package-specific current public
+version ranges. Example-local packages stay as local `file:` dependencies
+inside the exported tree, for example `@nestjs-yalc/skeleton-module` or
 `@nestjs-yalc/task-system-module`.
 
 The exported directories are the intended source for future read-only mirrors
 such as `nestjs-yalc-example-skeleton`, `nestjs-yalc-example-omnikernel`, and
-`nestjs-yalc-example-task-system`. Those mirrors should demonstrate how a
-consumer installs Yalc from npm, while the monorepo examples remain optimized
-for framework development and CI coverage.
+`nestjs-yalc-example-task`. Those mirrors should demonstrate how a consumer
+installs Yalc from npm, while the monorepo examples remain optimized for
+framework development and CI coverage.
+
+Each export also includes a standalone GitHub Actions workflow that installs the
+example app, builds it, and runs its e2e tests. See
+[Public example mirrors](./public-example-mirrors.md) for the repository sync
+workflow, required GitHub token, and read-only mirror operating model.

--- a/docs/public-example-mirrors.md
+++ b/docs/public-example-mirrors.md
@@ -13,11 +13,15 @@ The monorepo remains the source of truth for:
 
 ## Mirror repositories
 
-The intended mirror repositories are:
+The public mirror repositories are:
 
-- `NestDevLab/nestjs-yalc-example-skeleton`
-- `NestDevLab/nestjs-yalc-example-omnikernel`
-- `NestDevLab/nestjs-yalc-example-task`
+- [NestDevLab/nestjs-yalc-example-skeleton](https://github.com/NestDevLab/nestjs-yalc-example-skeleton)
+- [NestDevLab/nestjs-yalc-example-omnikernel](https://github.com/NestDevLab/nestjs-yalc-example-omnikernel)
+- [NestDevLab/nestjs-yalc-example-task](https://github.com/NestDevLab/nestjs-yalc-example-task)
+
+They are configured as public template repositories so consumers can start a new
+application from the generated example layout without cloning the full
+framework monorepo.
 
 The mirrors should be configured so normal users cannot push directly. Keep the
 default branch protected and allow writes only from maintainers or the sync
@@ -106,10 +110,15 @@ external pushes.
 Each generated mirror contains its own CI workflow. The workflow runs:
 
 ```bash
-npm install --prefer-offline --no-audit --prefix app
-npm run build --prefix app
-npm run test:e2e --prefix app
+npm install --prefer-offline --no-audit
+npm run build
+npm run test:e2e
 ```
+
+Each export has a generated root `package.json` with npm workspaces for `app`,
+`module`, and any additional local example modules. CI installs from the export
+root so sibling modules can resolve both the public framework packages and the
+example-local packages through the shared workspace dependency tree.
 
 The workflow uses `npm install` rather than `npm ci` because the exported
 template does not reuse monorepo lockfiles. If a mirror should become fully

--- a/docs/public-example-mirrors.md
+++ b/docs/public-example-mirrors.md
@@ -1,0 +1,123 @@
+# Public example mirrors
+
+The public example repositories are generated from the monorepo examples. They
+are read-only consumer templates, not independent development branches.
+
+The monorepo remains the source of truth for:
+
+- `examples/skeleton`: the minimal `CrudGenResourceFactory` path.
+- `examples/omnikernel`: the reusable OmniKernel backend plus generated REST and
+  GraphQL APIs.
+- `examples/task`: the larger composition example with OmniKernel persistence,
+  CrudGen APIs, API Strategy, EventManager, and e2e coverage.
+
+## Mirror repositories
+
+The intended mirror repositories are:
+
+- `NestDevLab/nestjs-yalc-example-skeleton`
+- `NestDevLab/nestjs-yalc-example-omnikernel`
+- `NestDevLab/nestjs-yalc-example-task`
+
+The mirrors should be configured so normal users cannot push directly. Keep the
+default branch protected and allow writes only from maintainers or the sync
+token used by the source repository workflow.
+
+## Export model
+
+Generate standalone sources with:
+
+```bash
+npm run examples:export
+```
+
+The command writes generated repositories under `var/example-exports`:
+
+- `var/example-exports/skeleton`
+- `var/example-exports/omnikernel`
+- `var/example-exports/task`
+
+Each export includes:
+
+- the example `app` and local example `module` packages;
+- any additional local example modules required by the app;
+- a generated `.github/workflows/ci.yml`;
+- a generated `.gitignore`;
+- `PUBLIC_EXPORT.md`, which explains that the repository is generated.
+
+Framework dependencies are rewritten from monorepo `file:` dependencies to the
+package-specific public npm range. Example-local packages remain `file:`
+dependencies inside the exported repository, because they are part of the
+template itself.
+
+## Mirror sync
+
+Sync all mirrors from the generated exports with:
+
+```bash
+npm run examples:mirror
+```
+
+Preview pending mirror changes without committing or pushing:
+
+```bash
+npm run examples:mirror:dry-run
+```
+
+The sync script expects the mirror repositories to already exist and to have a
+`main` branch. By default it targets the `NestDevLab` owner and these repository
+names:
+
+- `nestjs-yalc-example-skeleton`
+- `nestjs-yalc-example-omnikernel`
+- `nestjs-yalc-example-task`
+
+Override defaults with environment variables when needed:
+
+```bash
+EXAMPLE_MIRROR_OWNER=NestDevLab
+EXAMPLE_MIRROR_BRANCH=main
+EXAMPLE_MIRROR_SKELETON_REPOSITORY=nestjs-yalc-example-skeleton
+EXAMPLE_MIRROR_OMNIKERNEL_REPOSITORY=nestjs-yalc-example-omnikernel
+EXAMPLE_MIRROR_TASK_REPOSITORY=nestjs-yalc-example-task
+```
+
+For authenticated pushes, set `EXAMPLE_MIRROR_TOKEN` or `GH_TOKEN` to a GitHub
+token that can write to the mirror repositories.
+
+## GitHub Actions
+
+`.github/workflows/example-mirrors.yml` runs the mirror sync from the source
+repository. It can be triggered manually and also runs after changes to the
+canonical example folders or mirror scripts on `dev`.
+
+Configure this secret in `NestDevLab/nestjs-yalc` before enabling real pushes:
+
+```text
+EXAMPLE_MIRROR_TOKEN
+```
+
+Use a fine-grained GitHub token with write access only to the three mirror
+repositories. The source repository `GITHUB_TOKEN` is intentionally not used for
+external pushes.
+
+## Mirror CI
+
+Each generated mirror contains its own CI workflow. The workflow runs:
+
+```bash
+npm install --prefer-offline --no-audit --prefix app
+npm run build --prefix app
+npm run test:e2e --prefix app
+```
+
+The workflow uses `npm install` rather than `npm ci` because the exported
+template does not reuse monorepo lockfiles. If a mirror should become fully
+locked later, generate lockfiles inside the exported repository after dependency
+rewrites instead of copying workspace lockfiles from the monorepo.
+
+## Contribution model
+
+Do not edit mirror repositories directly. Apply changes to the corresponding
+monorepo example, run the example e2e suite, export the mirrors, and let the
+sync workflow update the public repositories.

--- a/examples/omnikernel/app/apps/omnikernel-app/src/crudgen-provider-compat.ts
+++ b/examples/omnikernel/app/apps/omnikernel-app/src/crudgen-provider-compat.ts
@@ -1,0 +1,19 @@
+import { Provider } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+export const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });

--- a/examples/omnikernel/app/apps/omnikernel-app/src/omni/omni-api.resources.ts
+++ b/examples/omnikernel/app/apps/omnikernel-app/src/omni/omni-api.resources.ts
@@ -1,4 +1,5 @@
 import { CrudGenResourceFactory } from '@nestjs-yalc/crud-gen';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import {
   OmniCollectionCondition,
   OmniCollectionCreateInput,
@@ -178,8 +179,8 @@ const omniResources = [
   omniExternalRefResource,
 ];
 
-export const omniApiProviders = omniResources.flatMap(
-  (resource) => resource.providers,
+export const omniApiProviders = omniResources.flatMap((resource) =>
+  bindGeneratedDataloaderEventEmitter(resource.providers),
 );
 export const omniApiControllers = omniResources.flatMap(
   (resource) => resource.controllers,

--- a/examples/omnikernel/app/webpack.config.js
+++ b/examples/omnikernel/app/webpack.config.js
@@ -1,5 +1,34 @@
+const ignoredOptionalModules = new Set([
+  '@apollo/gateway',
+  '@grpc/grpc-js',
+  '@grpc/proto-loader',
+  '@nestjs/websockets/socket-module',
+  'amqp-connection-manager',
+  'amqplib',
+  'apollo-server-fastify',
+  'class-transformer/storage',
+  'ioredis',
+  'kafkajs',
+  'mqtt',
+  'nats',
+  'ts-morph',
+]);
+
 module.exports = (options) => ({
   ...options,
+  externals: [
+    ...(Array.isArray(options.externals)
+      ? options.externals
+      : [options.externals].filter(Boolean)),
+    ({ request }, callback) => {
+      if (ignoredOptionalModules.has(request)) {
+        callback(null, `commonjs ${request}`);
+        return;
+      }
+
+      callback();
+    },
+  ],
   resolve: {
     ...options.resolve,
     extensionAlias: {

--- a/examples/omnikernel/module/src/omnikernel.module.ts
+++ b/examples/omnikernel/module/src/omnikernel.module.ts
@@ -1,4 +1,5 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OmniExternalRefEntity } from './base/omni-external-ref.entity';
 import { OmniNamedEntity } from './base/omni-named.entity';
@@ -17,21 +18,47 @@ import {
   omniKernelQueryServiceProviderFactory,
 } from './omnikernel.query.service';
 
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });
+
 @Module({})
 export class OmniKernelModule {
   static register(dbConnection: string): DynamicModule {
-    const omniNamedProviders = omniNamedBackendProvidersFactory(dbConnection);
-    const omniRecordProviders = omniRecordBackendProvidersFactory(dbConnection);
-    const omniRelationProviders =
-      omniRelationBackendProvidersFactory(dbConnection);
-    const omniCollectionProviders =
-      omniCollectionBackendProvidersFactory(dbConnection);
-    const omniDocumentProviders =
-      omniDocumentBackendProvidersFactory(dbConnection);
-    const omniExternalRefProviders =
-      omniExternalRefBackendProvidersFactory(dbConnection);
+    const omniNamedProviders = bindGeneratedDataloaderEventEmitter(
+      omniNamedBackendProvidersFactory(dbConnection).providers,
+    );
+    const omniRecordProviders = bindGeneratedDataloaderEventEmitter(
+      omniRecordBackendProvidersFactory(dbConnection).providers,
+    );
+    const omniRelationProviders = bindGeneratedDataloaderEventEmitter(
+      omniRelationBackendProvidersFactory(dbConnection).providers,
+    );
+    const omniCollectionProviders = bindGeneratedDataloaderEventEmitter(
+      omniCollectionBackendProvidersFactory(dbConnection).providers,
+    );
+    const omniDocumentProviders = bindGeneratedDataloaderEventEmitter(
+      omniDocumentBackendProvidersFactory(dbConnection).providers,
+    );
+    const omniExternalRefProviders = bindGeneratedDataloaderEventEmitter(
+      omniExternalRefBackendProvidersFactory(dbConnection).providers,
+    );
     const omniKernelQueryServiceProvider =
       omniKernelQueryServiceProviderFactory(dbConnection);
+    const eventEmitter = new EventEmitter2();
 
     return {
       module: OmniKernelModule,
@@ -49,21 +76,26 @@ export class OmniKernelModule {
         ),
       ],
       providers: [
-        ...omniNamedProviders.providers,
-        ...omniRecordProviders.providers,
-        ...omniRelationProviders.providers,
-        ...omniCollectionProviders.providers,
-        ...omniDocumentProviders.providers,
-        ...omniExternalRefProviders.providers,
+        {
+          provide: EventEmitter2,
+          useValue: eventEmitter,
+        },
+        ...omniNamedProviders,
+        ...omniRecordProviders,
+        ...omniRelationProviders,
+        ...omniCollectionProviders,
+        ...omniDocumentProviders,
+        ...omniExternalRefProviders,
         omniKernelQueryServiceProvider,
       ],
       exports: [
-        ...omniNamedProviders.providers,
-        ...omniRecordProviders.providers,
-        ...omniRelationProviders.providers,
-        ...omniCollectionProviders.providers,
-        ...omniDocumentProviders.providers,
-        ...omniExternalRefProviders.providers,
+        EventEmitter2,
+        ...omniNamedProviders,
+        ...omniRecordProviders,
+        ...omniRelationProviders,
+        ...omniCollectionProviders,
+        ...omniDocumentProviders,
+        ...omniExternalRefProviders,
         omniKernelQueryServiceProvider,
         OmniKernelQueryService,
       ],

--- a/examples/skeleton/app/apps/skeleton-app/src/crudgen-provider-compat.ts
+++ b/examples/skeleton/app/apps/skeleton-app/src/crudgen-provider-compat.ts
@@ -1,0 +1,19 @@
+import { Provider } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+export const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });

--- a/examples/skeleton/app/apps/skeleton-app/src/phones/phones.resource.ts
+++ b/examples/skeleton/app/apps/skeleton-app/src/phones/phones.resource.ts
@@ -6,6 +6,7 @@ import {
   SkeletonPhoneType,
   SkeletonPhoneUpdateInput,
 } from '@nestjs-yalc/skeleton-module';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 
 export const phonesResource = CrudGenResourceFactory<SkeletonPhone>({
   entityModel: SkeletonPhone,
@@ -36,4 +37,6 @@ export const phonesResource = CrudGenResourceFactory<SkeletonPhone>({
 });
 
 export const PhonesController = phonesResource.controllers[0];
-export const phonesResourceProviders = phonesResource.providers;
+export const phonesResourceProviders = bindGeneratedDataloaderEventEmitter(
+  phonesResource.providers,
+);

--- a/examples/skeleton/app/apps/skeleton-app/src/users/users.proxy.service.ts
+++ b/examples/skeleton/app/apps/skeleton-app/src/users/users.proxy.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import {
   HttpAbstractStrategy,
   IHttpCallStrategyResponse,
-} from '@nestjs-yalc/api-strategy';
+} from '@nestjs-yalc/api-strategy/strategies/http-abstract-call.strategy.js';
 
 export const USERS_HTTP_STRATEGY = 'USERS_HTTP_STRATEGY';
 

--- a/examples/skeleton/app/apps/skeleton-app/src/users/users.resource.ts
+++ b/examples/skeleton/app/apps/skeleton-app/src/users/users.resource.ts
@@ -18,6 +18,7 @@ import {
   SkeletonUserType,
   SkeletonUserUpdateInput,
 } from '@nestjs-yalc/skeleton-module';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 
 const skeletonUserServiceToken = 'SkeletonUserGenericService';
 
@@ -133,4 +134,6 @@ export const usersResource = CrudGenResourceFactory<SkeletonUser>({
 });
 
 export const UsersController = usersResource.controllers[0];
-export const usersResourceProviders = usersResource.providers;
+export const usersResourceProviders = bindGeneratedDataloaderEventEmitter(
+  usersResource.providers,
+);

--- a/examples/skeleton/app/apps/skeleton-app/test/crud-gen-sqlite.e2e-spec.ts
+++ b/examples/skeleton/app/apps/skeleton-app/test/crud-gen-sqlite.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { Test } from '@nestjs/testing';
 import { randomUUID } from 'node:crypto';
 import request from 'supertest';

--- a/examples/skeleton/app/webpack.config.js
+++ b/examples/skeleton/app/webpack.config.js
@@ -1,5 +1,34 @@
+const ignoredOptionalModules = new Set([
+  '@apollo/gateway',
+  '@grpc/grpc-js',
+  '@grpc/proto-loader',
+  '@nestjs/websockets/socket-module',
+  'amqp-connection-manager',
+  'amqplib',
+  'apollo-server-fastify',
+  'class-transformer/storage',
+  'ioredis',
+  'kafkajs',
+  'mqtt',
+  'nats',
+  'ts-morph',
+]);
+
 module.exports = (options) => ({
   ...options,
+  externals: [
+    ...(Array.isArray(options.externals)
+      ? options.externals
+      : [options.externals].filter(Boolean)),
+    ({ request }, callback) => {
+      if (ignoredOptionalModules.has(request)) {
+        callback(null, `commonjs ${request}`);
+        return;
+      }
+
+      callback();
+    },
+  ],
   resolve: {
     ...options.resolve,
     extensionAlias: {

--- a/examples/skeleton/module/src/skeleton.module.ts
+++ b/examples/skeleton/module/src/skeleton.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { skeletonUserProvidersFactory } from './skeleton-user.resolver.js';
@@ -6,11 +6,33 @@ import { skeletonPhoneProvidersFactory } from './skeleton-phone.resolver.js';
 import { SkeletonPhone } from './skeleton-phone.entity.js';
 import { SkeletonUser } from './skeleton-user.entity.js';
 
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });
+
 @Module({})
 export class SkeletonModule {
   static register(dbConnection: string): DynamicModule {
-    const skeletonPhoneProviders = skeletonPhoneProvidersFactory(dbConnection);
-    const skeletonUserProviders = skeletonUserProvidersFactory(dbConnection);
+    const skeletonPhoneProviders = bindGeneratedDataloaderEventEmitter(
+      skeletonPhoneProvidersFactory(dbConnection).providers,
+    );
+    const skeletonUserProviders = bindGeneratedDataloaderEventEmitter(
+      skeletonUserProvidersFactory(dbConnection).providers,
+    );
+    const eventEmitter = new EventEmitter2();
 
     return {
       module: SkeletonModule,
@@ -20,15 +42,15 @@ export class SkeletonModule {
       providers: [
         {
           provide: EventEmitter2,
-          useValue: new EventEmitter2(),
+          useValue: eventEmitter,
         },
-        ...skeletonPhoneProviders.providers,
-        ...skeletonUserProviders.providers,
+        ...skeletonPhoneProviders,
+        ...skeletonUserProviders,
       ],
       exports: [
         EventEmitter2,
-        ...skeletonPhoneProviders.providers,
-        ...skeletonUserProviders.providers,
+        ...skeletonPhoneProviders,
+        ...skeletonUserProviders,
       ],
     };
   }

--- a/examples/task/app/apps/task-system-app/src/crudgen-provider-compat.ts
+++ b/examples/task/app/apps/task-system-app/src/crudgen-provider-compat.ts
@@ -1,0 +1,19 @@
+import { Provider } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+export const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });

--- a/examples/task/app/apps/task-system-app/src/events/task-event.resource.ts
+++ b/examples/task/app/apps/task-system-app/src/events/task-event.resource.ts
@@ -6,6 +6,7 @@ import {
   getFn,
 } from '@nestjs-yalc/data-loader';
 import { TaskEvent } from '@nestjs-yalc/task-system-module/src/task-event.entity';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import { TaskAppOmniEventService } from '../omni-task-app/task-app-omni-event.service';
 import {
   TaskEventCondition,
@@ -51,4 +52,6 @@ export const taskEventResource = CrudGenResourceFactory<TaskEvent>({
 });
 
 export const EventsController = taskEventResource.controllers[0];
-export const taskEventProviders = taskEventResource.providers;
+export const taskEventProviders = bindGeneratedDataloaderEventEmitter(
+  taskEventResource.providers,
+);

--- a/examples/task/app/apps/task-system-app/src/projects/task-project.resource.ts
+++ b/examples/task/app/apps/task-system-app/src/projects/task-project.resource.ts
@@ -6,6 +6,7 @@ import {
   getFn,
 } from '@nestjs-yalc/data-loader';
 import { TaskProject } from '@nestjs-yalc/task-system-module/src/task-project.entity';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import { TaskAppOmniProjectService } from '../omni-task-app/task-app-omni-project.service';
 import {
   TaskProjectCondition,
@@ -51,4 +52,6 @@ export const taskProjectResource = CrudGenResourceFactory<TaskProject>({
 });
 
 export const ProjectsController = taskProjectResource.controllers[0];
-export const taskProjectProviders = taskProjectResource.providers;
+export const taskProjectProviders = bindGeneratedDataloaderEventEmitter(
+  taskProjectResource.providers,
+);

--- a/examples/task/app/apps/task-system-app/src/sync/task-external-ref.resource.ts
+++ b/examples/task/app/apps/task-system-app/src/sync/task-external-ref.resource.ts
@@ -6,6 +6,7 @@ import {
   getFn,
 } from '@nestjs-yalc/data-loader';
 import { TaskExternalRef } from '@nestjs-yalc/task-system-module/src/task-external-ref.entity';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import { TaskAppOmniExternalRefService } from '../omni-task-app/task-app-omni-external-ref.service';
 import {
   TaskExternalRefCondition,
@@ -51,4 +52,6 @@ export const taskExternalRefResource = CrudGenResourceFactory<TaskExternalRef>({
 });
 
 export const ExternalRefsController = taskExternalRefResource.controllers[0];
-export const taskExternalRefProviders = taskExternalRefResource.providers;
+export const taskExternalRefProviders = bindGeneratedDataloaderEventEmitter(
+  taskExternalRefResource.providers,
+);

--- a/examples/task/app/apps/task-system-app/src/sync/task-sync-state.resource.ts
+++ b/examples/task/app/apps/task-system-app/src/sync/task-sync-state.resource.ts
@@ -6,6 +6,7 @@ import {
   getFn,
 } from '@nestjs-yalc/data-loader';
 import { TaskSyncState } from '@nestjs-yalc/task-system-module/src/task-sync-state.entity';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import { TaskAppOmniSyncStateService } from '../omni-task-app/task-app-omni-sync-state.service';
 import {
   TaskSyncStateCondition,
@@ -51,4 +52,6 @@ export const taskSyncStateResource = CrudGenResourceFactory<TaskSyncState>({
 });
 
 export const SyncStatesController = taskSyncStateResource.controllers[0];
-export const taskSyncStateProviders = taskSyncStateResource.providers;
+export const taskSyncStateProviders = bindGeneratedDataloaderEventEmitter(
+  taskSyncStateResource.providers,
+);

--- a/examples/task/app/apps/task-system-app/src/tasks/task-item.resource.ts
+++ b/examples/task/app/apps/task-system-app/src/tasks/task-item.resource.ts
@@ -6,6 +6,7 @@ import {
   getFn,
 } from '@nestjs-yalc/data-loader';
 import { TaskItem } from '@nestjs-yalc/task-system-module/src/task-item.entity';
+import { bindGeneratedDataloaderEventEmitter } from '../crudgen-provider-compat.js';
 import { TaskAppOmniTaskService } from '../omni-task-app/task-app-omni-task.service';
 import {
   TaskItemCondition,
@@ -51,4 +52,6 @@ export const taskItemResource = CrudGenResourceFactory<TaskItem>({
 });
 
 export const TasksController = taskItemResource.controllers[0];
-export const taskItemProviders = taskItemResource.providers;
+export const taskItemProviders = bindGeneratedDataloaderEventEmitter(
+  taskItemResource.providers,
+);

--- a/examples/task/app/apps/task-system-app/src/tasks/tasks.proxy.service.ts
+++ b/examples/task/app/apps/task-system-app/src/tasks/tasks.proxy.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { IApiCallStrategy } from '@nestjs-yalc/api-strategy';
+import type { IApiCallStrategy } from '@nestjs-yalc/api-strategy';
 
 @Injectable()
 export class TasksProxyService {

--- a/examples/task/app/apps/task-system-app/test/task-system.e2e-spec.ts
+++ b/examples/task/app/apps/task-system-app/test/task-system.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { HttpService } from '@nestjs/axios';
 import { Test } from '@nestjs/testing';
 import { randomUUID } from 'node:crypto';

--- a/examples/task/app/webpack.config.js
+++ b/examples/task/app/webpack.config.js
@@ -1,5 +1,34 @@
+const ignoredOptionalModules = new Set([
+  '@apollo/gateway',
+  '@grpc/grpc-js',
+  '@grpc/proto-loader',
+  '@nestjs/websockets/socket-module',
+  'amqp-connection-manager',
+  'amqplib',
+  'apollo-server-fastify',
+  'class-transformer/storage',
+  'ioredis',
+  'kafkajs',
+  'mqtt',
+  'nats',
+  'ts-morph',
+]);
+
 module.exports = (options) => ({
   ...options,
+  externals: [
+    ...(Array.isArray(options.externals)
+      ? options.externals
+      : [options.externals].filter(Boolean)),
+    ({ request }, callback) => {
+      if (ignoredOptionalModules.has(request)) {
+        callback(null, `commonjs ${request}`);
+        return;
+      }
+
+      callback();
+    },
+  ],
   resolve: {
     ...options.resolve,
     extensionAlias: {

--- a/examples/task/module/src/task-event.entity.ts
+++ b/examples/task/module/src/task-event.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm';
+import type { Relation } from 'typeorm';
 import { TaskProject } from './task-project.entity.js';
 
 @Entity('task-event')
@@ -39,7 +40,7 @@ export class TaskEvent extends EntityWithTimestamps(BaseEntity) {
 
   @ManyToOne(() => TaskProject, (project) => project.events, { nullable: true })
   @JoinColumn({ name: 'projectId', referencedColumnName: 'guid' })
-  project?: TaskProject | null;
+  project?: Relation<TaskProject> | null;
 
   @Column('varchar', { nullable: true })
   location?: string | null;

--- a/examples/task/module/src/task-item.entity.ts
+++ b/examples/task/module/src/task-item.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm';
+import type { Relation } from 'typeorm';
 import { TaskProject } from './task-project.entity.js';
 
 @Entity('task-item')
@@ -30,7 +31,7 @@ export class TaskItem extends EntityWithTimestamps(BaseEntity) {
 
   @ManyToOne(() => TaskProject, (project) => project.tasks, { nullable: true })
   @JoinColumn({ name: 'projectId', referencedColumnName: 'guid' })
-  project?: TaskProject | null;
+  project?: Relation<TaskProject> | null;
 
   @Column('datetime', { nullable: true })
   dueAt?: Date | null;

--- a/examples/task/module/src/task-project.entity.ts
+++ b/examples/task/module/src/task-project.entity.ts
@@ -1,6 +1,7 @@
 import { EntityWithTimestamps } from '@nestjs-yalc/database/timestamp.entity.js';
 import { ObjectType } from '@nestjs/graphql';
 import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import type { Relation } from 'typeorm';
 import { TaskEvent } from './task-event.entity.js';
 import { TaskItem } from './task-item.entity.js';
 
@@ -20,8 +21,8 @@ export class TaskProject extends EntityWithTimestamps(BaseEntity) {
   status: string;
 
   @OneToMany(() => TaskItem, (task) => task.project)
-  tasks?: TaskItem[];
+  tasks?: Relation<TaskItem[]>;
 
   @OneToMany(() => TaskEvent, (event) => event.project)
-  events?: TaskEvent[];
+  events?: Relation<TaskEvent[]>;
 }

--- a/examples/task/module/src/task-system.module.ts
+++ b/examples/task/module/src/task-system.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Global, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TaskEvent } from './task-event.entity.js';
@@ -12,16 +12,43 @@ import { taskProjectProvidersFactory } from './task-project.resolver.js';
 import { TaskSyncState } from './task-sync-state.entity.js';
 import { taskSyncStateProvidersFactory } from './task-sync-state.resolver.js';
 
+type ProviderWithInject = Provider & { inject?: unknown[] };
+
+const bindGeneratedDataloaderEventEmitter = (
+  providers: Provider[],
+): Provider[] =>
+  providers.map((provider) => {
+    if (typeof provider !== 'object' || provider === null) return provider;
+
+    const providerWithInject = provider as ProviderWithInject;
+    if (!Array.isArray(providerWithInject.inject)) return provider;
+
+    return {
+      ...providerWithInject,
+      inject: providerWithInject.inject.map((token) => token ?? EventEmitter2),
+    } as Provider;
+  });
+
 @Global()
 @Module({})
 export class TaskSystemModule {
   static register(dbConnection: string): DynamicModule {
-    const taskProjectProviders = taskProjectProvidersFactory(dbConnection);
-    const taskItemProviders = taskItemProvidersFactory(dbConnection);
-    const taskEventProviders = taskEventProvidersFactory(dbConnection);
-    const taskExternalRefProviders =
-      taskExternalRefProvidersFactory(dbConnection);
-    const taskSyncStateProviders = taskSyncStateProvidersFactory(dbConnection);
+    const taskProjectProviders = bindGeneratedDataloaderEventEmitter(
+      taskProjectProvidersFactory(dbConnection).providers,
+    );
+    const taskItemProviders = bindGeneratedDataloaderEventEmitter(
+      taskItemProvidersFactory(dbConnection).providers,
+    );
+    const taskEventProviders = bindGeneratedDataloaderEventEmitter(
+      taskEventProvidersFactory(dbConnection).providers,
+    );
+    const taskExternalRefProviders = bindGeneratedDataloaderEventEmitter(
+      taskExternalRefProvidersFactory(dbConnection).providers,
+    );
+    const taskSyncStateProviders = bindGeneratedDataloaderEventEmitter(
+      taskSyncStateProvidersFactory(dbConnection).providers,
+    );
+    const eventEmitter = new EventEmitter2();
 
     return {
       module: TaskSystemModule,
@@ -34,21 +61,21 @@ export class TaskSystemModule {
       providers: [
         {
           provide: EventEmitter2,
-          useValue: new EventEmitter2(),
+          useValue: eventEmitter,
         },
-        ...taskProjectProviders.providers,
-        ...taskItemProviders.providers,
-        ...taskEventProviders.providers,
-        ...taskExternalRefProviders.providers,
-        ...taskSyncStateProviders.providers,
+        ...taskProjectProviders,
+        ...taskItemProviders,
+        ...taskEventProviders,
+        ...taskExternalRefProviders,
+        ...taskSyncStateProviders,
       ],
       exports: [
         EventEmitter2,
-        ...taskProjectProviders.providers,
-        ...taskItemProviders.providers,
-        ...taskEventProviders.providers,
-        ...taskExternalRefProviders.providers,
-        ...taskSyncStateProviders.providers,
+        ...taskProjectProviders,
+        ...taskItemProviders,
+        ...taskEventProviders,
+        ...taskExternalRefProviders,
+        ...taskSyncStateProviders,
       ],
     };
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "changeset:status": "changeset status",
     "version:packages": "changeset version && npm install --package-lock-only --ignore-scripts",
     "examples:export": "node ./scripts/export-public-examples.mjs",
+    "examples:mirror": "node ./scripts/sync-public-example-mirrors.mjs",
+    "examples:mirror:dry-run": "node ./scripts/sync-public-example-mirrors.mjs --dry-run",
     "test:vscode": "node test.js ",
     "npm:update:onlylock": "npm update --package-lock-only",
     "npm:outdated": "npm outdated",

--- a/scripts/export-public-examples.mjs
+++ b/scripts/export-public-examples.mjs
@@ -60,6 +60,10 @@ for (const example of examples) {
   }
 
   rewritePackageManifests(target, example.localPackages);
+  rewriteTsConfigPaths(target, example.localPackages);
+  rewriteE2eTsConfigs(target);
+  rewriteJestConfigs(target, example.localPackages);
+  writeRootPackageManifest(target, example);
   writeExportNotice(target, example.name);
   writeMirrorCi(target, example.name);
   writeMirrorGitignore(target);
@@ -99,6 +103,129 @@ function rewritePackageManifests(rootDir, localPackages) {
   }
 }
 
+function rewriteE2eTsConfigs(rootDir) {
+  for (const tsconfigPath of findFiles(rootDir, 'tsconfig.e2e.json')) {
+    const tsconfig = readJson(tsconfigPath);
+
+    tsconfig.compilerOptions = {
+      ...(tsconfig.compilerOptions ?? {}),
+      module: 'ESNext',
+      moduleResolution: 'node',
+    };
+
+    fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
+  }
+}
+
+function rewriteJestConfigs(rootDir, localPackages) {
+  for (const jestConfigPath of findFiles(rootDir, 'jest-e2e.json')) {
+    const config = readJson(jestConfigPath);
+
+    if (!config.moduleNameMapper) {
+      continue;
+    }
+
+    config.extensionsToTreatAsEsm = ['.ts'];
+
+    const tsTransform = config.transform?.['^.+\\.ts$'];
+    if (Array.isArray(tsTransform) && typeof tsTransform[1] === 'object') {
+      tsTransform[1].useESM = true;
+    }
+
+    const mapper = {};
+
+    if (config.moduleNameMapper['^p-map$']) {
+      mapper['^p-map$'] = config.moduleNameMapper['^p-map$'];
+    }
+
+    for (const [packageName, dependencyPath] of localPackages.entries()) {
+      const localPath = dependencyPath.replace(/^file:\.\.\//, '');
+      mapper[`^${escapeRegExp(packageName)}$`] =
+        `<rootDir>/../../../../${localPath}/src`;
+      mapper[`^${escapeRegExp(packageName)}/src/(.*)$`] =
+        `<rootDir>/../../../../${localPath}/src/$1`;
+    }
+
+    for (const [pattern, replacement] of Object.entries(
+      config.moduleNameMapper,
+    )) {
+      if (
+        pattern.startsWith('^@nestjs-yalc/') ||
+        pattern === '^@nestjs/(.*)$' ||
+        pattern === '^typeorm$' ||
+        pattern === '^p-map$' ||
+        pattern === '^lodash-es$' ||
+        pattern === '^(\\.{1,2}/.*)\\.js$'
+      ) {
+        continue;
+      }
+
+      mapper[pattern] = replacement;
+    }
+
+    mapper['^@nestjs/(.*)$'] = '<rootDir>/../../../../node_modules/@nestjs/$1';
+    mapper['^typeorm$'] = '<rootDir>/../../../../node_modules/typeorm';
+    mapper['^@nestjs-yalc/([^/]+)/(.+?)\\.js$'] =
+      '<rootDir>/../../../../node_modules/@nestjs-yalc/$1/src/$2';
+    mapper['^@nestjs-yalc/([^/]+)/(.*)$'] =
+      '<rootDir>/../../../../node_modules/@nestjs-yalc/$1/src/$2';
+    mapper['^@nestjs-yalc/([^/]+)$'] =
+      '<rootDir>/../../../../node_modules/@nestjs-yalc/$1/src';
+
+    if (config.moduleNameMapper['^(\\.{1,2}/.*)\\.js$']) {
+      mapper['^(\\.{1,2}/.*)\\.js$'] =
+        config.moduleNameMapper['^(\\.{1,2}/.*)\\.js$'];
+    }
+
+    config.moduleNameMapper = mapper;
+    fs.writeFileSync(jestConfigPath, `${JSON.stringify(config, null, 2)}\n`);
+  }
+}
+
+function rewriteTsConfigPaths(rootDir, localPackages) {
+  const publicPackageNames = new Set(publicPackageVersions.keys());
+
+  for (const tsconfigPath of findFiles(rootDir, 'tsconfig.json')) {
+    const tsconfig = readJson(tsconfigPath);
+    const paths = tsconfig.compilerOptions?.paths;
+
+    if (!paths) {
+      continue;
+    }
+
+    // The public export installs dependencies from its generated workspace root,
+    // so monorepo-relative dependency aliases must be rewritten to the exported
+    // repository layout rather than removed.
+    paths['@nestjs/*'] = ['../node_modules/@nestjs/*'];
+    paths.typeorm = ['../node_modules/typeorm'];
+    delete paths['nestjs-yalc'];
+    delete paths['nestjs-yalc/*'];
+
+    for (const packageName of publicPackageNames) {
+      paths[packageName] = [
+        `../node_modules/${packageName}/src/index.js`,
+        `../node_modules/${packageName}/src/index.d.ts`,
+      ];
+      paths[`${packageName}/*`] = [
+        `../node_modules/${packageName}/*`,
+        `../node_modules/${packageName}/src/*`,
+      ];
+    }
+
+    for (const [packageName, dependencyPath] of localPackages.entries()) {
+      const localPath = dependencyPath.replace(/^file:/, '');
+      paths[packageName] = [`${localPath}/src/index.ts`];
+      paths[`${packageName}/*`] = [`${localPath}/*`, `${localPath}/src/*`];
+    }
+
+    fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function versionRangeForPublicPackage(packageName) {
   return `^${publicPackageVersions.get(packageName)}`;
 }
@@ -125,6 +252,31 @@ function writeExportNotice(target, exampleName) {
   ].join('\n');
 
   fs.writeFileSync(path.join(target, 'PUBLIC_EXPORT.md'), notice);
+}
+
+function writeRootPackageManifest(target, example) {
+  const workspaceNames = ['app', 'module'];
+
+  for (const extraCopy of example.extraCopies ?? []) {
+    workspaceNames.push(extraCopy.to);
+  }
+
+  const manifest = {
+    name: `nestjs-yalc-example-${example.name}`,
+    private: true,
+    version: '0.0.0',
+    description: `Generated public ${example.name} example for nestjs-yalc`,
+    scripts: {
+      build: 'npm run build --prefix app',
+      'test:e2e': 'npm run test:e2e --prefix app',
+    },
+    workspaces: workspaceNames,
+  };
+
+  fs.writeFileSync(
+    path.join(target, 'package.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
 }
 
 function writeMirrorCi(target, exampleName) {
@@ -162,13 +314,13 @@ function writeMirrorCi(target, exampleName) {
     '          node-version: ${{ env.NODE_VERSION }}',
     '',
     '      - name: Install example dependencies',
-    '        run: npm install --prefer-offline --no-audit --prefix app',
+    '        run: npm install --prefer-offline --no-audit',
     '',
     '      - name: Build example app',
-    '        run: npm run build --prefix app',
+    '        run: npm run build',
     '',
     '      - name: Run example e2e tests',
-    '        run: npm run test:e2e --prefix app',
+    '        run: npm run test:e2e',
     '',
   ].join('\n');
 

--- a/scripts/export-public-examples.mjs
+++ b/scripts/export-public-examples.mjs
@@ -5,16 +5,21 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const rootPackage = readJson(path.join(repoRoot, 'package.json'));
 const outputRoot = path.join(repoRoot, 'var', 'example-exports');
-const publicVersionRange = `^${rootPackage.version}`;
-const publicPackageNames = new Set(
-  [
-    rootPackage.name,
-    ...(rootPackage.workspaces ?? []).map((workspacePath) => {
-      const packagePath = path.join(repoRoot, workspacePath, 'package.json');
-      return fs.existsSync(packagePath) ? readJson(packagePath).name : undefined;
-    }),
-  ].filter(Boolean),
-);
+const publicPackageVersions = new Map([[rootPackage.name, rootPackage.version]]);
+
+for (const workspacePath of rootPackage.workspaces ?? []) {
+  const packagePath = path.join(repoRoot, workspacePath, 'package.json');
+
+  if (!fs.existsSync(packagePath)) {
+    continue;
+  }
+
+  const manifest = readJson(packagePath);
+
+  if (manifest.name && manifest.version) {
+    publicPackageVersions.set(manifest.name, manifest.version);
+  }
+}
 
 const examples = [
   {
@@ -56,6 +61,8 @@ for (const example of examples) {
 
   rewritePackageManifests(target, example.localPackages);
   writeExportNotice(target, example.name);
+  writeMirrorCi(target, example.name);
+  writeMirrorGitignore(target);
   console.log(`exported ${example.name} -> ${path.relative(repoRoot, target)}`);
 }
 
@@ -81,14 +88,19 @@ function rewritePackageManifests(rootDir, localPackages) {
           continue;
         }
 
-        if (publicPackageNames.has(dependencyName)) {
-          manifest[section][dependencyName] = publicVersionRange;
+        if (publicPackageVersions.has(dependencyName)) {
+          manifest[section][dependencyName] =
+            versionRangeForPublicPackage(dependencyName);
         }
       }
     }
 
     fs.writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
   }
+}
+
+function versionRangeForPublicPackage(packageName) {
+  return `^${publicPackageVersions.get(packageName)}`;
 }
 
 function writeExportNotice(target, exampleName) {
@@ -98,8 +110,11 @@ function writeExportNotice(target, exampleName) {
     `This directory is a generated export of the \`${exampleName}\` example.`,
     '',
     'It is intended to be mirrored into a read-only example repository. Framework',
-    'dependencies are rewritten to public `@nestjs-yalc/*` npm versions, while',
+    'dependencies are rewritten to package-specific public npm versions, while',
     'example-local modules stay as local `file:` dependencies.',
+    '',
+    'Do not edit the mirror repository directly. Change the source example in',
+    '`NestDevLab/nestjs-yalc`, regenerate the export, and sync the mirror.',
     '',
     'Regenerate it from the framework monorepo with:',
     '',
@@ -110,6 +125,68 @@ function writeExportNotice(target, exampleName) {
   ].join('\n');
 
   fs.writeFileSync(path.join(target, 'PUBLIC_EXPORT.md'), notice);
+}
+
+function writeMirrorCi(target, exampleName) {
+  const workflowDir = path.join(target, '.github', 'workflows');
+  fs.mkdirSync(workflowDir, { recursive: true });
+
+  const workflow = [
+    'name: example ci',
+    '',
+    'on:',
+    '  workflow_dispatch:',
+    '  push:',
+    '    branches:',
+    '      - main',
+    '  pull_request:',
+    '',
+    'env:',
+    '  NODE_VERSION: 24',
+    '  NODE_ENV: pipeline',
+    '  JWT_SECRET_PVT: dummydummy',
+    '  JWT_SECRET_PUB: dummydummy',
+    '',
+    'jobs:',
+    '  e2e:',
+    `    name: ${exampleName} example e2e`,
+    '    runs-on: ubuntu-latest',
+    '',
+    '    steps:',
+    '      - name: Checkout',
+    '        uses: actions/checkout@v4',
+    '',
+    '      - name: Setup Node',
+    '        uses: actions/setup-node@v4',
+    '        with:',
+    '          node-version: ${{ env.NODE_VERSION }}',
+    '',
+    '      - name: Install example dependencies',
+    '        run: npm install --prefer-offline --no-audit --prefix app',
+    '',
+    '      - name: Build example app',
+    '        run: npm run build --prefix app',
+    '',
+    '      - name: Run example e2e tests',
+    '        run: npm run test:e2e --prefix app',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(workflowDir, 'ci.yml'), workflow);
+}
+
+function writeMirrorGitignore(target) {
+  const gitignore = [
+    'node_modules/',
+    'dist/',
+    'coverage/',
+    '.env',
+    '.env.*',
+    '!.env.example',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(target, '.gitignore'), gitignore);
 }
 
 function copyDir(from, to) {

--- a/scripts/sync-public-example-mirrors.mjs
+++ b/scripts/sync-public-example-mirrors.mjs
@@ -1,0 +1,150 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has('--dry-run');
+const owner = getOption('owner') ?? process.env.EXAMPLE_MIRROR_OWNER ?? 'NestDevLab';
+const branch = getOption('branch') ?? process.env.EXAMPLE_MIRROR_BRANCH ?? 'main';
+const cloneRoot = path.join(repoRoot, 'var', 'example-mirrors');
+const exportRoot = path.join(repoRoot, 'var', 'example-exports');
+
+const mirrors = [
+  {
+    name: 'skeleton',
+    repository:
+      process.env.EXAMPLE_MIRROR_SKELETON_REPOSITORY ??
+      'nestjs-yalc-example-skeleton',
+  },
+  {
+    name: 'omnikernel',
+    repository:
+      process.env.EXAMPLE_MIRROR_OMNIKERNEL_REPOSITORY ??
+      'nestjs-yalc-example-omnikernel',
+  },
+  {
+    name: 'task',
+    repository:
+      process.env.EXAMPLE_MIRROR_TASK_REPOSITORY ??
+      'nestjs-yalc-example-task',
+  },
+];
+
+run('npm', ['run', 'examples:export'], repoRoot);
+fs.mkdirSync(cloneRoot, { recursive: true });
+
+for (const mirror of mirrors) {
+  const sourceDir = path.join(exportRoot, mirror.name);
+  const targetDir = path.join(cloneRoot, mirror.name);
+
+  if (!fs.existsSync(sourceDir)) {
+    throw new Error(`Missing generated example export: ${sourceDir}`);
+  }
+
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  run(
+    'git',
+    [
+      'clone',
+      '--branch',
+      branch,
+      '--single-branch',
+      mirrorUrl(mirror.repository),
+      targetDir,
+    ],
+    repoRoot,
+  );
+
+  replaceRepositoryContents(sourceDir, targetDir);
+
+  const status = getOutput('git', ['status', '--short'], targetDir);
+
+  if (!status.trim()) {
+    console.log(`${mirror.name}: no mirror changes`);
+    continue;
+  }
+
+  if (dryRun) {
+    console.log(`${mirror.name}: pending mirror changes`);
+    console.log(status);
+    continue;
+  }
+
+  run('git', ['add', '--all'], targetDir);
+  run(
+    'git',
+    ['commit', '-m', 'chore: sync generated example from nestjs-yalc'],
+    targetDir,
+  );
+  run('git', ['push', 'origin', branch], targetDir);
+}
+
+function getOption(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function mirrorUrl(repository) {
+  const token = process.env.EXAMPLE_MIRROR_TOKEN ?? process.env.GH_TOKEN;
+
+  if (token) {
+    return `https://x-access-token:${token}@github.com/${owner}/${repository}.git`;
+  }
+
+  return `https://github.com/${owner}/${repository}.git`;
+}
+
+function replaceRepositoryContents(sourceDir, targetDir) {
+  for (const entry of fs.readdirSync(targetDir, { withFileTypes: true })) {
+    if (entry.name === '.git') {
+      continue;
+    }
+
+    fs.rmSync(path.join(targetDir, entry.name), {
+      recursive: true,
+      force: true,
+    });
+  }
+
+  copyDir(sourceDir, targetDir);
+}
+
+function copyDir(from, to) {
+  fs.mkdirSync(to, { recursive: true });
+
+  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+    const sourcePath = path.join(from, entry.name);
+    const targetPath = path.join(to, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDir(sourcePath, targetPath);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+function getOutput(command, commandArgs, cwd) {
+  return execFileSync(command, commandArgs, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function run(command, commandArgs, cwd) {
+  console.log(`$ ${command} ${commandArgs.map(sanitizeArg).join(' ')}`);
+  execFileSync(command, commandArgs, {
+    cwd,
+    stdio: 'inherit',
+  });
+}
+
+function sanitizeArg(arg) {
+  return arg.replace(/x-access-token:[^@]+@github\.com/g, 'x-access-token:***@github.com');
+}

--- a/scripts/sync-public-example-mirrors.mjs
+++ b/scripts/sync-public-example-mirrors.mjs
@@ -10,6 +10,10 @@ const owner = getOption('owner') ?? process.env.EXAMPLE_MIRROR_OWNER ?? 'NestDev
 const branch = getOption('branch') ?? process.env.EXAMPLE_MIRROR_BRANCH ?? 'main';
 const cloneRoot = path.join(repoRoot, 'var', 'example-mirrors');
 const exportRoot = path.join(repoRoot, 'var', 'example-exports');
+const mirrorToken = process.env.EXAMPLE_MIRROR_TOKEN ?? process.env.GH_TOKEN;
+const gitAuthHeader = mirrorToken
+  ? `Authorization: Basic ${Buffer.from(`x-access-token:${mirrorToken}`).toString('base64')}`
+  : undefined;
 
 const mirrors = [
   {
@@ -31,6 +35,12 @@ const mirrors = [
       'nestjs-yalc-example-task',
   },
 ];
+
+if (!dryRun && !mirrorToken) {
+  throw new Error(
+    'EXAMPLE_MIRROR_TOKEN or GH_TOKEN is required when pushing public example mirrors.',
+  );
+}
 
 run('npm', ['run', 'examples:export'], repoRoot);
 fs.mkdirSync(cloneRoot, { recursive: true });
@@ -55,6 +65,7 @@ for (const mirror of mirrors) {
       targetDir,
     ],
     repoRoot,
+    { auth: Boolean(gitAuthHeader) },
   );
 
   replaceRepositoryContents(sourceDir, targetDir);
@@ -78,7 +89,7 @@ for (const mirror of mirrors) {
     ['commit', '-m', 'chore: sync generated example from nestjs-yalc'],
     targetDir,
   );
-  run('git', ['push', 'origin', branch], targetDir);
+  run('git', ['push', 'origin', branch], targetDir, { auth: true });
 }
 
 function getOption(name) {
@@ -87,12 +98,6 @@ function getOption(name) {
 }
 
 function mirrorUrl(repository) {
-  const token = process.env.EXAMPLE_MIRROR_TOKEN ?? process.env.GH_TOKEN;
-
-  if (token) {
-    return `https://x-access-token:${token}@github.com/${owner}/${repository}.git`;
-  }
-
   return `https://github.com/${owner}/${repository}.git`;
 }
 
@@ -134,17 +139,41 @@ function getOutput(command, commandArgs, cwd) {
     cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: gitEnv(),
   });
 }
 
-function run(command, commandArgs, cwd) {
-  console.log(`$ ${command} ${commandArgs.map(sanitizeArg).join(' ')}`);
-  execFileSync(command, commandArgs, {
+function run(command, commandArgs, cwd, options = {}) {
+  const finalArgs = withGitAuth(command, commandArgs, options.auth);
+  console.log(`$ ${command} ${finalArgs.map(sanitizeArg).join(' ')}`);
+  execFileSync(command, finalArgs, {
     cwd,
     stdio: 'inherit',
+    env: gitEnv(),
   });
 }
 
 function sanitizeArg(arg) {
-  return arg.replace(/x-access-token:[^@]+@github\.com/g, 'x-access-token:***@github.com');
+  return arg
+    .replace(/x-access-token:[^@]+@github\.com/g, 'x-access-token:***@github.com')
+    .replace(/Authorization: Basic \S+/g, 'Authorization: Basic ***');
+}
+
+function withGitAuth(command, commandArgs, auth) {
+  if (command !== 'git' || !auth || !gitAuthHeader) {
+    return commandArgs;
+  }
+
+  return [
+    '-c',
+    `http.https://github.com/.extraheader=${gitAuthHeader}`,
+    ...commandArgs,
+  ];
+}
+
+function gitEnv() {
+  return {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+  };
 }


### PR DESCRIPTION
## Summary
- generate standalone CI workflows, gitignore files, and export notices for public example exports
- rewrite exported @nestjs-yalc dependencies to package-specific public npm version ranges
- add mirror sync tooling and a source workflow for read-only external example repositories
- document the public example mirror operating model

## Verification
- node --check scripts/export-public-examples.mjs
- node --check scripts/sync-public-example-mirrors.mjs
- npm run examples:export
- git diff --check
- npm run ci:checks

## Notes
The sync workflow expects the external mirror repositories and EXAMPLE_MIRROR_TOKEN to be configured before real pushes are enabled.