### PR TITLE
revert: require mirror token on dev sync

### DIFF
--- a/.github/workflows/example-mirrors.yml
+++ b/.github/workflows/example-mirrors.yml
@@ -54,23 +54,20 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Inspect mirror token
-        id: mirror-token
+      - name: Check mirror token
         env:
           EXAMPLE_MIRROR_TOKEN: ${{ secrets.EXAMPLE_MIRROR_TOKEN }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
         run: |
           if [ "$DRY_RUN" != "true" ] && [ -z "$EXAMPLE_MIRROR_TOKEN" ]; then
-            echo "::warning::EXAMPLE_MIRROR_TOKEN is not configured. Running mirror sync in dry-run mode."
-            echo "dry_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+            echo "EXAMPLE_MIRROR_TOKEN is required to push external mirror repositories."
+            exit 1
           fi
 
       - name: Sync mirrors
         env:
           EXAMPLE_MIRROR_TOKEN: ${{ secrets.EXAMPLE_MIRROR_TOKEN }}
-          DRY_RUN: ${{ steps.mirror-token.outputs.dry_run }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
         run: |
           if [ "$DRY_RUN" = "true" ]; then
             npm run examples:mirror:dry-run


### PR DESCRIPTION
## Summary\n- revert #133 so the public example mirror workflow fails when EXAMPLE_MIRROR_TOKEN is missing\n- keep missing mirror credentials visible as a required repository setup step\n\n## Why\nThe mirror sync is expected to publish external repositories on dev pushes. A missing token should be a visible configuration failure, not a silent dry-run.\n\n## Verification\n- git revert 5d57118